### PR TITLE
2025 01 network part 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
 - Execute SignIn tests via `npx playwright test dishSignIn.spec.ts`
 
 ### Failure tests
-- Main Menu Network option only in Small Screen Mode (3 lines) 
+- Example: Main Menu Network option only in Small Screen Mode (3 lines) 
   - Manually check that Main Menu in Small Screen Mode still has Network option
 - Test File: `dishFailures.spec.ts`
 - To execute tests - remove skip from tests
@@ -72,6 +72,20 @@
   - change from `test(..)` to `test.skip(..)`
 - Execute Failure tests via `npx playwright test dishFailures.spec.ts`
 - UI Failure tests `npx playwright test dishFailures.spec.ts --ui`
+#### Menu Network option - solution
+- Set Browser width <= 1024 displays `Menu Network`
+- Fixed failed tests and moved to Network Menu Spec file
+  - With set Browser width before all tests
+  - TODO set Browser width for specific test 
+- TODO create Dish Network page Model to check network lists
+  - API https://radish.dishanywhere.com/v20/dol/networks/home.json
+    - fields: slug, name, network_id, vod_download, network_players (list), 
+    - fields: network_player, banner, is_ad_free, howcount, moviecount,  
+    - fields: franchise_count, has_live_content, logo, promo (list)
+  - Unlocked Networks via API `"is_locked": false`
+  - Live Networks via API `"has_stream": true`
+  - Latino Networks via API `"is_latino_package_network": true`
+  - Movie Pack Networks via API `"is_bb": true`
 
 ### Fix now or later Failed tests 
 - Run UI for Spec file with consistent failed tests

--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@
 - Execute Failure tests via `npx playwright test dishFailures.spec.ts`
 - UI Failure tests `npx playwright test dishFailures.spec.ts --ui`
 
+### Fix now or later Failed tests 
+- Run UI for Spec file with consistent failed tests
+  - Example Spec file: "dishBase.spec.ts" has Test: "Dish Base Copyright" fails
+  - Example`npx playwright test dishBase.spec.ts --ui`
+- Have playwright only run the failed tests via change from `test(..)` to `test.only(..)`
+  - Example `test('Dish Base Copyright', ....)` to `test.only('Dish Base Copyright', ...)`
+- Option 1: Debug and fix failed tests
+  - Then change back from `test.only(..)` to `test(..)`
+  - Run complete spec file to see if fix caused other failures
+  - Might what to run all spec file test before check-in fixes
+- Option 2: Debug and decide to fix later
+  - Document failure reason and why fix later
+  - Now change `test.only(..)` to `test.skip(..)`
+  - Might want to move failed test to a spec failure file
+
 ### Other Execute options
 - Run all tests, all browsers, not display browsers, max workers
   - `npx playwright test`

--- a/models/dishBasePage.ts
+++ b/models/dishBasePage.ts
@@ -90,7 +90,7 @@ export class DishAnywhereBasePage {
 
     async getCopyText(debug?:boolean):Promise<string> {
         const elemText:string = await this.copyright.innerText();
-        if (debug) console.log(elemText)
+        if (debug) console.log(`web: ${elemText}`)
         return elemText;
     }
 
@@ -106,7 +106,6 @@ export class DishAnywhereBasePage {
         await menuItem.isVisible();
         await menuItem.click();
         await this.page.waitForURL(`${expNewUrl}`)
-        expect(this.page.url()).toBe(expNewUrl);
     }
 
     

--- a/models/dishBasePage.ts
+++ b/models/dishBasePage.ts
@@ -22,6 +22,9 @@ export class DishAnywhereBasePage {
     protected _webEnv: string;
     protected _loggedIn: boolean;
     protected _hideFooter: boolean
+    protected _hasMenuIcon: boolean
+
+    private _maxIconWidth:number = 1024;
 
     constructor(page: Page, baseURL: string, env: string, hide?:boolean) {
         this.page = page;
@@ -30,7 +33,8 @@ export class DishAnywhereBasePage {
         this._webEnv = env;
         this._loggedIn = false;
 
-        this._hideFooter = (hide?true:false)
+        this._hideFooter = (hide?true:false);
+        this._hasMenuIcon = false;
 
         // Menu items 
         this.menuIcon = page.locator('div#menu-button');
@@ -43,6 +47,7 @@ export class DishAnywhereBasePage {
         this.menuOnDemand = this.topMenus.locator('a#on-demand-menu-item');
         this.menuSignIn =  this.topMenus.locator('a#sign-in-menu-item');
 
+        // only displayed with Menu Icon
         this.menuNetworks =  this.topMenus.locator('a#networks-menu-item');
         
         // Copyright 
@@ -52,6 +57,10 @@ export class DishAnywhereBasePage {
     
     async goto():Promise<void> {
         await this.page.goto(`${this._webBaseURL}/`);
+
+        const browserWidth = await this.page.evaluate(() => window.innerWidth);
+        this._hasMenuIcon = browserWidth <= this._maxIconWidth
+        console.log(`Menu Icon: ${this._hasMenuIcon}; width: ${browserWidth}`);
 
         // wait for top Menus, default (Home) URL and copyright visible
         await this.topMenus.isVisible();
@@ -78,6 +87,10 @@ export class DishAnywhereBasePage {
         return this._loggedIn;
     }
 
+    hasMenuIcon(): boolean {
+        return this._hasMenuIcon;
+    }
+
     async hoverCopyElem():Promise<void> {
         await this.copyright.hover();
     }
@@ -92,15 +105,17 @@ export class DishAnywhereBasePage {
         return elemText;
     }
 
-    async clickMenuIcon(debug?:boolean): Promise<void> {
-        await this.menuIcon.click()
+    async clickMenuIcon(): Promise<void> {
+        if (this._hasMenuIcon) {await this.menuIcon.click()}
     }
 
     protected async _clickMenuItem(
         menuItem:Locator, 
-        debug?:boolean) {
-        const browserWidth = await this.page.evaluate(() => window.innerWidth);
-        console.log(`Browser width: ${browserWidth}`);
+        isMenu:boolean,
+        debug?:boolean) 
+    {
+        if (isMenu) await this.clickMenuIcon()
+            
         const href = await menuItem.getAttribute('href');
         const expNewUrl = `${this._webBaseURL}${href}`
         if (debug) {
@@ -117,7 +132,7 @@ export class DishAnywhereBasePage {
     }
     
     async clickMenuHome(debug?:boolean): Promise<void> {
-        await this._clickMenuItem(this.menuHome, debug)
+        await this._clickMenuItem(this.menuHome, true, debug)
     }
 
     async menuHomeText(): Promise<string> {
@@ -125,7 +140,7 @@ export class DishAnywhereBasePage {
     }
     
     async clickMenuGuide(debug?:boolean): Promise<void> {
-        await this._clickMenuItem(this.menuGuide, debug)
+        await this._clickMenuItem(this.menuGuide, true, debug)
     }
 
     async menuGuideText(): Promise<string> {
@@ -133,7 +148,7 @@ export class DishAnywhereBasePage {
     }
 
     async clickMenuDVR(debug?:boolean): Promise<void> {
-        await this._clickMenuItem(this.menuDVR, debug)
+        await this._clickMenuItem(this.menuDVR, true, debug)
     }
 
     async menuDVRText(): Promise<string> {
@@ -141,7 +156,7 @@ export class DishAnywhereBasePage {
     }
 
     async clickMenuSports(debug?:boolean): Promise<void> {
-        await this._clickMenuItem(this.menuSports, debug)
+        await this._clickMenuItem(this.menuSports, true, debug)
     }
 
     async menuSportsText(): Promise<string> {
@@ -149,7 +164,7 @@ export class DishAnywhereBasePage {
     }
 
     async clickMenuOnDemand(debug?:boolean): Promise<void> {
-        await this._clickMenuItem(this.menuOnDemand, debug)
+        await this._clickMenuItem(this.menuOnDemand, true, debug)
     }
     
     async menuOnDemandText(): Promise<string> {
@@ -157,7 +172,7 @@ export class DishAnywhereBasePage {
     }
 
     async clickMenuNetworks(debug?:boolean): Promise<void> {
-        await this._clickMenuItem(this.menuNetworks, debug)
+        await this._clickMenuItem(this.menuNetworks, true, debug)
     }
 
     async menuNetworksText(): Promise<string> {
@@ -165,7 +180,7 @@ export class DishAnywhereBasePage {
     }
 
     async clickMenuSignIn(debug?:boolean): Promise<void> {
-        await this._clickMenuItem(this.menuSignIn, debug)
+        await this._clickMenuItem(this.menuSignIn, true, debug)
     }
 
     async menuSignInText(): Promise<string> {

--- a/models/dishBasePage.ts
+++ b/models/dishBasePage.ts
@@ -5,6 +5,7 @@ export class DishAnywhereBasePage {
 
     readonly page: Page;
 
+    readonly menuIcon:Locator
     readonly topMenus:Locator
     readonly menuItems:Locator
     readonly menuHome:Locator
@@ -32,6 +33,7 @@ export class DishAnywhereBasePage {
         this._hideFooter = (hide?true:false)
 
         // Menu items 
+        this.menuIcon = page.locator('div#menu-button');
         this.topMenus = page.locator('div#top-menu-items-container');
         this.menuItems = this.topMenus.locator('a');
         this.menuHome = this.topMenus.locator('a#home-menu-item');
@@ -60,11 +62,9 @@ export class DishAnywhereBasePage {
         await this.copyright.isVisible();
     }
 
-    
     getHideFooter(): boolean {
         return this._hideFooter
     }
-
 
     getWebBaseURL(): string {
         return this._webBaseURL
@@ -82,8 +82,6 @@ export class DishAnywhereBasePage {
         await this.copyright.hover();
     }
 
-    
-
     async getMenuItemCount():Promise<number> {
         return await this.menuItems.count();
     }
@@ -94,9 +92,15 @@ export class DishAnywhereBasePage {
         return elemText;
     }
 
+    async clickMenuIcon(debug?:boolean): Promise<void> {
+        await this.menuIcon.click()
+    }
+
     protected async _clickMenuItem(
         menuItem:Locator, 
         debug?:boolean) {
+        const browserWidth = await this.page.evaluate(() => window.innerWidth);
+        console.log(`Browser width: ${browserWidth}`);
         const href = await menuItem.getAttribute('href');
         const expNewUrl = `${this._webBaseURL}${href}`
         if (debug) {
@@ -108,10 +112,8 @@ export class DishAnywhereBasePage {
         await this.page.waitForURL(`${expNewUrl}`)
     }
 
-    
     protected async _getItemText(menuItem:Locator):Promise<string> {
         return await menuItem.innerText();
-       
     }
     
     async clickMenuHome(debug?:boolean): Promise<void> {
@@ -126,7 +128,6 @@ export class DishAnywhereBasePage {
         await this._clickMenuItem(this.menuGuide, debug)
     }
 
-    
     async menuGuideText(): Promise<string> {
         return await this._getItemText(this.menuGuide)
     }
@@ -155,11 +156,11 @@ export class DishAnywhereBasePage {
         return await this._getItemText(this.menuOnDemand)
     }
 
-    async clickMenuNetwork(debug?:boolean): Promise<void> {
+    async clickMenuNetworks(debug?:boolean): Promise<void> {
         await this._clickMenuItem(this.menuNetworks, debug)
     }
 
-    async menuNetworkText(): Promise<string> {
+    async menuNetworksText(): Promise<string> {
         return await this._getItemText(this.menuNetworks)
     }
 

--- a/models/dishDVRPage.ts
+++ b/models/dishDVRPage.ts
@@ -45,7 +45,7 @@ export class DishAnywhereDVRPage extends DishAnywhereBasePage {
 
     async clickSignInButton(debug?:boolean): Promise<void> {
         expect(this.isLoggedIn()).toBeFalsy();
-        await this._clickMenuItem(this.signInObj.getButtonElem(), debug);
+        await this._clickMenuItem(this.signInObj.getButtonElem(), false, debug);
     }
 
 }

--- a/models/dishGuidePage.ts
+++ b/models/dishGuidePage.ts
@@ -45,7 +45,7 @@ export class DishAnywhereGuidePage extends DishAnywhereBasePage {
 
     async clickSignInButton(debug?:boolean): Promise<void> {
         expect(this.isLoggedIn()).toBeFalsy();
-        await this._clickMenuItem(this.signInObj.getButtonElem(), debug);
+        await this._clickMenuItem(this.signInObj.getButtonElem(), false, debug);
     }
 
 }

--- a/models/dishHealthCheck.ts
+++ b/models/dishHealthCheck.ts
@@ -29,7 +29,11 @@ export class DishHealthCheckAPI {
         const data:CheckJson = await response.json()
         this._env = data.env;
         this._branch = data.git.branch;
-        this._webVer = this._branch.replace(/-/g,".");
+        // API branch version format = 'yy-q-s' for year, quarter, sprint
+        //          with optional '-p' for patch
+        // Web release version is only 'yy.q.s' so need to ignore optional '-p'
+        const [year, sprint, quarter] = this._branch.split('-')
+        this._webVer = year + '.' + sprint + '.' + quarter
     }
 
     getEnv(): String {

--- a/models/dishOnDemandPage.ts
+++ b/models/dishOnDemandPage.ts
@@ -44,7 +44,7 @@ export class DishAnywhereOnDemandPage extends DishAnywhereBasePage {
 
     async clickSignInButton(debug?:boolean): Promise<void> {
         expect(this.isLoggedIn()).toBeFalsy();
-        await this._clickMenuItem(this.signInObj.getButtonElem(), debug);
+        await this._clickMenuItem(this.signInObj.getButtonElem(), false, debug);
     }
 
 }

--- a/models/dishSportsPage.ts
+++ b/models/dishSportsPage.ts
@@ -45,7 +45,7 @@ export class DishAnywhereSportsPage extends DishAnywhereBasePage {
 
     async clickSignInButton(debug?:boolean): Promise<void> {
         expect(this.isLoggedIn()).toBeFalsy();
-        await this._clickMenuItem(this.signInObj.getButtonElem(), debug);
+        await this._clickMenuItem(this.signInObj.getButtonElem(), false, debug);
     }
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
+      "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.49.1"
+        "playwright": "1.50.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "version": "22.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
+      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -55,13 +55,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
+      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.1"
+        "playwright-core": "1.50.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
+      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/tests/dishBase.spec.ts
+++ b/tests/dishBase.spec.ts
@@ -20,10 +20,10 @@ test('Dish Base Menu Count', async ({ page }) => {
     console.log(`Base Menu: ${amount} items`)
     expect(amount).toEqual(6);
 });
+
 test('Dish Base Menu Home', async ({ page }) => {
     const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
     await basePage.goto();
-    
     await basePage.clickMenuHome(true);
 });
 

--- a/tests/dishDVR.spec.ts
+++ b/tests/dishDVR.spec.ts
@@ -8,6 +8,11 @@ import { genCheckCopyright, checkMenuTextValues, expSignInButton,
 const webBaseUrl = "https://www.dishanywhere.com";
 const webApiEnv = 'production';
 
+// Menu Icon Browser width <= 1024
+test.use({
+    viewport: {width: 1020, height: 800}
+});
+
 test('Dish DVR Copyright', async ({ page, request }) => {
     const dvrPage = new DishAnywhereDVRPage(page, webBaseUrl, webApiEnv);
     await dvrPage.goto(true);

--- a/tests/dishFailures.spec.ts
+++ b/tests/dishFailures.spec.ts
@@ -23,15 +23,15 @@ test('Dish Network Menu Count', async ({ page }) => {
 
 // from file: dishBase.spec.ts
 // Menu Networks only with Menu Icon Bar not with Menu List Bar
-test.skip('Dish Base Menu Networks', async ({ page }) => {
+test('Dish Base Menu Networks', async ({ page }) => {
     const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
     await basePage.goto();
-    await basePage.clickMenuIcon();
+    // clickMenuNetworks does clickMenuIcon();
     await basePage.clickMenuNetworks(true);
 });
 
 // when above 'Menu Networks' test pass then run this test
-test.skip('Dish Base Network Text', async ({ page }) => {
+test('Dish Base Network Text', async ({ page }) => {
     const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
     await basePage.goto();
     await basePage.clickMenuIcon();

--- a/tests/dishFailures.spec.ts
+++ b/tests/dishFailures.spec.ts
@@ -4,6 +4,9 @@ import { DishAnywhereBasePage } from '../models/dishBasePage';;
 const webBaseUrl = "https://www.dishanywhere.com";
 const webApiEnv = 'production';
 
+// 
+
+
 // from file: dishBase.spec.ts
 // Menu Networks only with Menu Icon Bar not with Menu List Bar
 test.skip('Dish Base Menu Networks', async ({ page }) => {

--- a/tests/dishFailures.spec.ts
+++ b/tests/dishFailures.spec.ts
@@ -4,21 +4,37 @@ import { DishAnywhereBasePage } from '../models/dishBasePage';;
 const webBaseUrl = "https://www.dishanywhere.com";
 const webApiEnv = 'production';
 
-// 
+// Menu Icon only displayed on screen with width <= 1024
+// Need to click on Menu Icon to display Menu Options
+// Menu Icon Options include Network 
+// Menu Bar Options not include Network
 
+test.use({
+    viewport: {width: 1020, height: 800}
+});
+
+test('Dish Network Menu Count', async ({ page }) => {
+    const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
+    await basePage.goto();
+    const amount:number = await basePage.getMenuItemCount()
+    console.log(`Base Menu: ${amount} items`)
+    expect(amount).toEqual(7);
+});
 
 // from file: dishBase.spec.ts
 // Menu Networks only with Menu Icon Bar not with Menu List Bar
-test.skip('Dish Base Menu Networks', async ({ page }) => {
+test('Dish Base Menu Networks', async ({ page }) => {
     const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
     await basePage.goto();
-    await basePage.clickMenuNetwork(true);
+    await basePage.clickMenuIcon();
+    await basePage.clickMenuNetworks(true);
 });
 
 // when above 'Menu Networks' test pass then run this test
-test.skip('Dish Base Network Text', async ({ page }) => {
+test('Dish Base Network Text', async ({ page }) => {
     const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
     await basePage.goto();
-    let menuText = await basePage.menuNetworkText();
+    await basePage.clickMenuIcon();
+    let menuText = await basePage.menuNetworksText();
     expect(menuText).toBe("Networks")
 });

--- a/tests/dishFailures.spec.ts
+++ b/tests/dishFailures.spec.ts
@@ -23,6 +23,7 @@ test('Dish Network Menu Count', async ({ page }) => {
 
 // from file: dishBase.spec.ts
 // Menu Networks only with Menu Icon Bar not with Menu List Bar
+// Need set spec test browser width to move to dishBase.spec.ts
 test('Dish Base Menu Networks', async ({ page }) => {
     const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
     await basePage.goto();

--- a/tests/dishFailures.spec.ts
+++ b/tests/dishFailures.spec.ts
@@ -23,7 +23,7 @@ test('Dish Network Menu Count', async ({ page }) => {
 
 // from file: dishBase.spec.ts
 // Menu Networks only with Menu Icon Bar not with Menu List Bar
-test('Dish Base Menu Networks', async ({ page }) => {
+test.skip('Dish Base Menu Networks', async ({ page }) => {
     const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
     await basePage.goto();
     await basePage.clickMenuIcon();
@@ -31,7 +31,7 @@ test('Dish Base Menu Networks', async ({ page }) => {
 });
 
 // when above 'Menu Networks' test pass then run this test
-test('Dish Base Network Text', async ({ page }) => {
+test.skip('Dish Base Network Text', async ({ page }) => {
     const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
     await basePage.goto();
     await basePage.clickMenuIcon();

--- a/tests/dishGuide.spec.ts
+++ b/tests/dishGuide.spec.ts
@@ -8,6 +8,11 @@ import { genCheckCopyright, checkMenuTextValues, expSignInButton,
 const webBaseUrl = "https://www.dishanywhere.com";
 const webApiEnv = 'production';
 
+// Menu List Browser width > 1024
+test.use({
+    viewport: {width: 1080, height: 800}
+});
+
 test('Dish Guide Menu Texts', async ({ page }) => {
     const guidePage = new DishAnywhereGuidePage(page, webBaseUrl, webApiEnv);
     await guidePage.goto(true);

--- a/tests/dishHelper.ts
+++ b/tests/dishHelper.ts
@@ -44,7 +44,7 @@ export async function genCheckCopyright(
                 :`©${year} DISH Network L.L.C. All rights reserved. Version ${webVer}`)
     // await dishPage.hoverCopyElem();
     const copyRightText = await dishPage.getCopyText(debug);
-    if (debug) console.log(`expWright: ${copyRightExp}`)
+    if (debug) console.log(`exp: ${copyRightExp}`)
     expect(copyRightText).toBe(copyRightExp)
 }
 

--- a/tests/dishHelper.ts
+++ b/tests/dishHelper.ts
@@ -52,20 +52,43 @@ export async function checkMenuTextValues(
     dishPage: DishAnywhereBasePage,
     debug?:boolean
 ): Promise<void> {
+
+    await dishPage.clickMenuIcon()
+
     const homeText = await dishPage.menuHomeText();
+    const homeExp = "Home";
+
     const guideText = await dishPage.menuGuideText();
+    const guideExp = "Guide";
+    
     const dvrText = await dishPage.menuDVRText();
+    const dvrExp = "DVR";
+    
     const sportsText = await dishPage.menuSportsText();
+    const sportsnExp = "Sports";
+    
     const onDemandText = await dishPage.menuOnDemandText();
+    const onDemandExp = "On Demand";
+    
     const signInText = await dishPage.menuSignInText();
+    const signInExp = "Sign in";
+    
+    let networksText = "";
+    let networksExp = "";
+
+    if (dishPage.hasMenuIcon()) {
+        networksText = await dishPage.menuNetworksText();
+        networksExp = "Networks";
+    }
 
     if (debug) {
-        console.log(`menu: ${homeText}; ${guideText}; ${dvrText}; ${sportsText}; ${onDemandText}; ${signInText};`)
+        console.log(`menu: ${homeText}; ${guideText}; ${dvrText}; ${sportsText}; ${onDemandText}; ${signInText}; ${networksText};`)
     }
-    expect(homeText).toBe("Home")
-    expect(guideText).toBe("Guide")
-    expect(dvrText).toBe("DVR")
-    expect(sportsText).toBe("Sports")
-    expect(onDemandText).toBe("On Demand")
-    expect(signInText).toBe("Sign in")
+    expect(homeText).toBe(homeExp)
+    expect(guideText).toBe(guideExp)
+    expect(dvrText).toBe(dvrExp)
+    expect(sportsText).toBe(sportsnExp)
+    expect(onDemandText).toBe(onDemandExp)
+    expect(signInText).toBe(signInExp)
+    expect(networksText).toBe(networksExp)
 }

--- a/tests/dishNetworks.spec.ts
+++ b/tests/dishNetworks.spec.ts
@@ -2,7 +2,7 @@ import { test, expect} from '@playwright/test';
 import { DishAnywhereBasePage } from '../models/dishBasePage';;
 
 import { DishHealthCheckAPI } from '../models/dishHealthCheck';
-import { genCheckCopyright } from './dishHelper';
+import { genCheckCopyright,  checkMenuTextValues } from './dishHelper';
 
 const webBaseUrl = "https://www.dishanywhere.com";
 const webApiEnv = 'production';
@@ -26,18 +26,25 @@ test('Dish Network Menu Count', async ({ page }) => {
 test('Dish Base Menu Networks', async ({ page }) => {
     const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
     await basePage.goto();
-    await basePage.clickMenuIcon();
     await basePage.clickMenuNetworks(true);
 });
 
-test.only('Dish Network Copyright', async ({ page, request }) => {
+test('Dish Network Copyright', async ({ page, request }) => {
     const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
     await basePage.goto();
-    await basePage.clickMenuIcon();
     await basePage.clickMenuNetworks(true);
     
     const health = new DishHealthCheckAPI(request);
     await genCheckCopyright(basePage, health, true)
+});
+
+
+test('Dish Network Menu Texts', async ({ page }) => {
+    const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
+    await basePage.goto();
+    await basePage.clickMenuNetworks(true);
+    
+    await checkMenuTextValues(basePage, true)
 });
 
 test('Dish Base Network Text', async ({ page }) => {

--- a/tests/dishNetworks.spec.ts
+++ b/tests/dishNetworks.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect} from '@playwright/test';
+import { DishAnywhereBasePage } from '../models/dishBasePage';;
+
+import { DishHealthCheckAPI } from '../models/dishHealthCheck';
+import { genCheckCopyright } from './dishHelper';
+
+const webBaseUrl = "https://www.dishanywhere.com";
+const webApiEnv = 'production';
+
+// Menu Icon only displayed on screen with width <= 1024
+// Need to click on Menu Icon to display Menu Options
+// Menu Networks only with Menu Icon not with Menu List
+
+test.use({
+    viewport: {width: 1020, height: 800}
+});
+
+test('Dish Network Menu Count', async ({ page }) => {
+    const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
+    await basePage.goto();
+    const amount:number = await basePage.getMenuItemCount()
+    console.log(`Base Menu: ${amount} items`)
+    expect(amount).toEqual(7);
+});
+
+test('Dish Base Menu Networks', async ({ page }) => {
+    const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
+    await basePage.goto();
+    await basePage.clickMenuIcon();
+    await basePage.clickMenuNetworks(true);
+});
+
+test.only('Dish Network Copyright', async ({ page, request }) => {
+    const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
+    await basePage.goto();
+    await basePage.clickMenuIcon();
+    await basePage.clickMenuNetworks(true);
+    
+    const health = new DishHealthCheckAPI(request);
+    await genCheckCopyright(basePage, health, true)
+});
+
+test('Dish Base Network Text', async ({ page }) => {
+    const basePage = new DishAnywhereBasePage(page, webBaseUrl, webApiEnv);
+    await basePage.goto();
+    await basePage.clickMenuIcon();
+    let menuText = await basePage.menuNetworksText();
+    expect(menuText).toBe("Networks")
+});


### PR DESCRIPTION
Set browser width for all spec test in file <= 1024 to display network menu - fixed
- Passed all failed spec network tests
- added network menu spec test file 
- TODO Set a test's browser width 
- TODO Model Network page 
- TODO Check display networks via API call

API release version patch not in web display - fixed
- API version format "yy-q-s" (year, quarter, sprint) with optional "-p" (patch)
-  Web version format "yy.q.s" (year, quarter, sprint) 


